### PR TITLE
Support cross-platform command line options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required (VERSION 2.8.11)
 project (COMPHOT)
 
 set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+
 # Find required modules
 include (gd)
 include (cfitsio)
+include (boost)
 
 set (SRC_FILES
+    src/app.cpp
     src/comphot.c
     src/proclib.c
 )
@@ -15,6 +18,10 @@ set (SRC_FILES
 # Output binary comphot
 add_executable (comphot ${SRC_FILES})
 set (EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})
+
+# Set compiler requirements
+set_target_properties (comphot PROPERTIES CXX_STANDARD 11)
+set_target_properties (comphot PROPERTIES CXX_STANDARD_REQUIRED ON)
 
 # Set include directories
 set (INCLUDE_PATHS ${INCLUDE_PATHS} ${CFITSIO_INCLUDE_PATH})

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ Comet photometry developed for the BAA comet section.
 
 ## Building
 ### Dependencies
+#### Boost
+Download latest from http://www.boost.org
+
+Follow the included documentation for building on your platform, e.g. for Linux:
+```
+./bootstrap.sh
+sudo ./b2 install
+```
+
 #### cfitsio:
 Download latest from http://heasarc.gsfc.nasa.gov/fitsio/
 e.g. http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3410.tar.gz

--- a/cmake/modules/boost.cmake
+++ b/cmake/modules/boost.cmake
@@ -1,0 +1,9 @@
+# Find Boost include and lib paths
+
+set(Boost_USE_STATIC_LIBS ON)
+find_package(Boost REQUIRED COMPONENTS
+    program_options
+)
+
+set (INCLUDE_PATHS ${INCLUDE_PATHS} ${Boost_INCLUDE_DIRS})
+set (LIBRARY_PATHS ${LIBRARY_PATHS} ${Boost_LIBRARIES})

--- a/cmake/modules/gd.cmake
+++ b/cmake/modules/gd.cmake
@@ -6,7 +6,7 @@ find_path (GD_INCLUDE_PATH
 )
 
 if (WIN32)
-    SET(GD_NAMES ${GD_NAMES} bgd)
+    SET(GD_NAMES ${GD_NAMES} gd bgd libgd)
 else (WIN32)
     SET(GD_NAMES ${GD_NAMES} gd)
 endif (WIN32)

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,0 +1,169 @@
+#include <string>
+#include <iostream>
+
+#include <boost/program_options.hpp>
+
+extern "C"
+{
+#include "comphot.h"
+}
+
+namespace bpo = boost::program_options;
+namespace
+{
+// Program option data parsed from command line
+struct Options
+{
+    std::string offsetimage;
+    std::string fixedimage;
+    std::string flatimage;
+    int cenx = 0;
+    int ceny = 0;
+    float apradius = -1; // Default is to use auto
+};
+
+// Valid options must contain an offset and fixed image
+bool isValid( const Options& options )
+{
+    return !options.offsetimage.empty() &&
+        !options.fixedimage.empty();
+}
+
+std::ostream& printUsage(
+    std::ostream& out,
+    const char* name,
+    const bpo::options_description& options )
+{
+    out << "Usage: " << name << " [options] offsetimage fixedimage cenx ceny:\n"
+        << "\n  offsetimage/fixedimage Offset and fixed images (FIT)"
+        << "\n  cenx/centy             Photocentre (pixels)"
+        << "\n\nOptions:\n"
+        << options << '\n';
+
+    return out;
+}
+
+// Parse options from command line with the help of boost
+// to handle Windows/Linux and other platforms
+Options parseOptions( int argc, char** argv )
+{
+    Options options;
+
+    // Required options that are expected to be given on
+    // the command line without any option name
+    bpo::options_description required;
+    required.add_options()
+    (
+        "offsetimage",
+        bpo::value< std::string >( &options.offsetimage )->required()
+    )
+    (
+        "fixedimage",
+        bpo::value< std::string >( &options.fixedimage )->required()
+    )
+    (
+        "cenx",
+        bpo::value< int >( &options.cenx )->required()
+    )
+    (
+        "ceny",
+        bpo::value< int >( &options.ceny )->required()
+    );
+
+    // Optional options that can be specified on the command line
+    // using their given option names
+    bpo::options_description optional;
+    optional.add_options()
+    (
+        "apmax,r",
+        bpo::value< float >( &options.apradius ),
+        "Optional photometric (arcsec)"
+    )
+    (
+        "flatimage,f",
+        bpo::value< std::string >( &options.flatimage ),
+        "Optional flat normalization image (TIF)"
+    )
+    (
+        "help,h",
+        "Usage info"
+    );
+
+    bpo::options_description all;
+    all.add( required ).add( optional );
+
+    // Set up the options that we expect without any option names
+    bpo::positional_options_description pos;
+    pos.add( "offsetimage", 1 );
+    pos.add( "fixedimage", 1 );
+    pos.add( "cenx", 1 );
+    pos.add( "ceny", 1 );
+
+    bpo::variables_map vm;
+
+    try
+    {
+        bpo::store(
+            bpo::command_line_parser( argc, argv )
+                .options( all )
+                .positional( pos )
+                .run(), vm );
+
+        if ( vm.count( "help" ) )
+        {
+            printUsage( std::cout, argv[ 0 ], optional );
+        }
+        else
+        {
+            // Check validity of all given options
+            bpo::notify( vm );
+        }
+    }
+    catch ( const bpo::error& e )
+    {
+        std::cout << "Error: " << e.what() << '\n';
+        printUsage( std::cout, argv[ 0 ], optional );
+    }
+
+    return options;
+}
+
+// Convert option data to comphot internal format
+ComphotConfig createComphotConfig( const Options& options )
+{
+    ComphotConfig config;
+    config.offsetimage = options.offsetimage.c_str();
+    config.fixedimage = options.fixedimage.c_str();
+    config.cenx = options.cenx;
+    config.ceny = options.ceny;
+    config.apradius = options.apradius;
+
+    if ( !options.flatimage.empty() )
+    {
+        config.flatimage = options.flatimage.c_str();
+    }
+    else
+    {
+        config.flatimage = nullptr;
+    }
+
+    return config;
+}
+} // namespace
+
+int main( int argc, char* argv[] )
+{
+    Options options = parseOptions( argc, argv );
+
+    if ( isValid( options ) )
+    {
+        ComphotConfig config = createComphotConfig( options );
+        // call comphot to process
+        process( &config );
+
+        return 0;
+    }
+
+    return 1;
+}
+

--- a/src/comphot.h
+++ b/src/comphot.h
@@ -1,0 +1,17 @@
+#ifndef COMPHOT_H
+#define COMPHOT_H
+#pragma once
+
+typedef struct {
+	const char* offsetimage;
+	const char* fixedimage;
+	const char* flatimage;
+	int cenx;
+	int ceny;
+	float apradius;
+} ComphotConfig;
+
+void process( const ComphotConfig* config );
+
+#endif // COMPHOT_H
+

--- a/src/proclib.h
+++ b/src/proclib.h
@@ -1,4 +1,8 @@
-#define	MAXLEN	1000
+#ifndef PROCLIB_H
+#define PROCLIB_H
+#pragma once
+
+#include <fitsio.h>
 
 typedef	struct {
 	double x,y;
@@ -39,3 +43,6 @@ int handle_status(int *status, int warning, const char *msg);
 float *img_filt(float *img, long axes[], int rad);
 
 int checksize(long img1[2], long img2[2]);
+
+#endif // PROCLIB_H
+


### PR DESCRIPTION
- Move the command line option parsing logic out of comphot.c to app.cpp (which now contains `main` )
- Use boost::program_options to handle option parsing to support multiple platforms
- Fix linking issue on Windows for gdFontMediumBold
- Update README